### PR TITLE
Document How to Find Cluster Resources

### DIFF
--- a/HOWTO_HPC_GettingStarted.md
+++ b/HOWTO_HPC_GettingStarted.md
@@ -175,7 +175,7 @@ https://docs.rc.fas.harvard.edu/kb/convenient-slurm-commands/
 The following command uses [sinfo](https://slurm.schedmd.com/sinfo.html) to list the partition, number of CPUs active/idle/other/total, GPUs assigned to node, GPUs currently in use.
 
 ```
-sinfo -O "Partition:20,CPUsState:30,GresUsed:30,Gres:30"
+sinfo -O "Partition:20,CPUsState:20,Gres:20,GresUsed:30""
 ```
 
 To identify a node that should be available to run your job, find a node that has your required number of CPUs idle and your required number of GPUs not in use.

--- a/HOWTO_HPC_GettingStarted.md
+++ b/HOWTO_HPC_GettingStarted.md
@@ -4,6 +4,7 @@ Jump to:
 * [Interactive job with NSF CC*-funded A100 GPUs](#a100-gpus)
 * [Batch](#batch)
 * [Debugging](#debugging)
+* [Finding Available Resources](#finding-available-resources)
 
 # Login via SSH
 
@@ -167,3 +168,14 @@ Note that the "%20" suffix ensures it prints out 20 characters worth of info abo
 
 For more, see: 
 https://docs.rc.fas.harvard.edu/kb/convenient-slurm-commands/
+
+# Finding Available Resources
+
+
+The following command uses [sinfo](https://slurm.schedmd.com/sinfo.html) to list the partition, number of CPUs active/idle/other/total, GPUs assigned to node, GPUs currently in use.
+
+```
+sinfo -O "Partition:20,CPUsState:30,GresUsed:30,Gres:30"
+```
+
+To identify a node that should be available to run your job, find a node that has your required number of CPUs idle and your required number of GPUs not in use.

--- a/HOWTO_HPC_GettingStarted.md
+++ b/HOWTO_HPC_GettingStarted.md
@@ -190,7 +190,7 @@ https://docs.rc.fas.harvard.edu/kb/convenient-slurm-commands/
 The following command uses [sinfo](https://slurm.schedmd.com/sinfo.html) to list the partition, number of CPUs active/idle/other/total, GPUs assigned to node, GPUs currently in use.
 
 ```
-sinfo -O "Partition:20,CPUsState:20,Gres:20,GresUsed:30""
+sinfo -O "Partition:20,CPUsState:20,Gres:20,GresUsed:30"
 ```
 
 To identify a node that should be available to run your job, find a node that has your required number of CPUs idle and your required number of GPUs not in use.


### PR DESCRIPTION
**Reason:** It can be difficult to identify which partitions in the cluster have resources available and Slurm does not make this information easily accessible.

**Fix:** Document a SLURM command that shows which CPU and GPU resources are available in each node making up a partition.

**Verification:** Verified command works and is well formatted for HPC. Example output:

```
PARTITION           CPUS(A/I/O/T)       GRES                GRES_USED
interactive         26/54/0/80          (null)              gpu:0
batch*              1622/2018/400/4040  (null)              gpu:0
mpi                 1622/2018/384/4024  (null)              gpu:0
gpu                 48/0/80/128         gpu:a100:8          gpu:a100:2(IDX:0,7)
gpu                 40/32/0/72          gpu:p100:4          gpu:p100:3(IDX:0,2-3)
gpu                 256/0/0/256         gpu:a100:8          gpu:a100:8(IDX:0-7)
gpu                 128/0/0/128         gpu:a100:8          gpu:a100:5(IDX:0-2,4-5)
gpu                 0/80/0/80           gpu:k20xm:1         gpu:k20xm:0(IDX:N/A)
largemem            176/144/200/520     (null)              gpu:0
ccgpu               32/0/32/64          gpu:a100:8          gpu:a100:4(IDX:1-2,4-5)
ccgpu               146/46/0/192        gpu:a100:8          gpu:a100:8(IDX:0-7)
ccgpu               14/50/0/64          gpu:a100:7          gpu:a100:7(IDX:0-6)
hugheslab           16/80/0/96          gpu:rtx_6000:8      gpu:rtx_6000:8(IDX:0-7)
hugheslab           64/32/0/96          gpu:rtx_a6000:8     gpu:rtx_a6000:8(IDX:0-7)
preempt             2128/2336/328/4792  (null)              gpu:0
preempt             32/0/32/64          gpu:a100:8          gpu:a100:4(IDX:1-2,4-5)
preempt             48/0/80/128         gpu:a100:8          gpu:a100:2(IDX:0,7)
preempt             402/46/0/448        gpu:a100:8          gpu:a100:8(IDX:0-7)
preempt             14/50/0/64          gpu:a100:7          gpu:a100:7(IDX:0-6)
preempt             4/60/0/64           gpu:v100:3          gpu:v100:1(IDX:0)
preempt             40/32/0/72          gpu:p100:4          gpu:p100:3(IDX:0,2-3)
preempt             18/54/0/72          gpu:v100:4          gpu:v100:4(IDX:0-3)
preempt             6/66/0/72           gpu:p100:6          gpu:p100:3(IDX:0-2)
preempt             8/56/0/64           gpu:v100:2          gpu:v100:2(IDX:0-1)
preempt             206/34/0/240        gpu:t4:4            gpu:t4:2(IDX:0-1)
preempt             2/62/0/64           gpu:a100:2          gpu:a100:1(IDX:1)
preempt             52/44/0/96          gpu:a100:2          gpu:a100:2(IDX:0-1)
preempt             16/80/0/96          gpu:a100:2          gpu:a100:0(IDX:N/A)
preempt             64/32/0/96          gpu:rtx_a6000:8     gpu:rtx_a6000:8(IDX:0-7)
preempt             32/96/0/128         gpu:rtx_6000ada:4   gpu:rtx_6000ada:0(IDX:N/A)
preempt             80/0/0/80           gpu:t4:4            gpu:t4:0(IDX:N/A)
preempt             152/8/0/160         gpu:t4:4            gpu:t4:2(IDX:2-3)
preempt             796/324/0/1120      gpu:t4:4            gpu:t4:4(IDX:0-3)
preempt             128/0/0/128         gpu:a100:8          gpu:a100:5(IDX:0-2,4-5)
preempt             0/80/0/80           gpu:k20xm:1         gpu:k20xm:0(IDX:N/A)
preempt             0/64/0/64           gpu:v100:4          gpu:v100:0(IDX:N/A)
preempt             0/64/0/64           gpu:rtx_6000:2      gpu:rtx_6000:0(IDX:N/A)
preempt             0/224/0/224         gpu:h100:3          gpu:h100:0(IDX:N/A)
preempt             0/128/0/128         gpu:l40s:4          gpu:l40s:0(IDX:N/A)
```