### PR TITLE
Create HOWTO_host_a_website.md

### DIFF
--- a/HOWTO_HPC_GettingStarted.md
+++ b/HOWTO_HPC_GettingStarted.md
@@ -5,6 +5,7 @@ Jump to:
 * [Batch](#batch)
 * [Debugging](#debugging)
 * [Finding Available Resources](#finding-available-resources)
+* [Cancelling All Your Jobs](#cancelling-all-your-jobs)
 
 # Login via SSH
 
@@ -194,3 +195,11 @@ sinfo -O "Partition:20,CPUsState:20,Gres:20,GresUsed:30"
 ```
 
 To identify a node that should be available to run your job, find a node that has your required number of CPUs idle and your required number of GPUs not in use.
+
+# Cancelling All Your Jobs
+
+The following command drops the header from `squeue`, grabs your job IDs, and then cancels those IDs with `scancel`.
+
+```
+squeue -u $USER | tail -n +2 | awk '{print $1}' | xargs scancel
+```

--- a/HOWTO_host_a_website.md
+++ b/HOWTO_host_a_website.md
@@ -1,0 +1,14 @@
+# [GitHub Pages](https://pages.github.com/)
+
+Free web hosting for static sites.
+Will default to `username.github.io` with optional `/repo_name/` at the end, but also supports hosting for a custom domain that you have bought elsewhere.
+
+# EECS User Hosting
+
+These instructions will serve a website from `https://www.cs.tufts.edu/~EECS_username/`.
+
+1. SSH into `linux.eecs.tufts.edu` with your EECS username and password.
+2. In your home directory run `mkdir public_html; chmod 775 public_html`.
+3. Place website files into `public_html` and apply `chmod 644` on all files you want to be publicly available.
+4. Wait a minute before testing the site so changes have time to take effect.
+5. Visit https://www.cs.tufts.edu/~EECS_username/ or https://www.eecs.tufts.edu/~EECS_username/ to view the website. This will load `index.html` but you can view other files by adding the appropriate path to the end of the URL.


### PR DESCRIPTION
**Reason:** repo does not currently provide instructions on website hosting, which is useful for promoting yourself and your work.

**Fix:** linked to instructions for GitHub Pages and provided instructions for EECS user hosting.

**Validation:** EECS instructions have been tested, with a working example at https://www.cs.tufts.edu/~pfeene01/.

**Future Work:** instructions on the method used to host sites such as https://novelcraft.cs.tufts.edu/ or https://www.cs.tufts.edu/cs/136/2024s/.